### PR TITLE
Add Factories tab for SuperScalar channel factory management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,168 +1,107 @@
 <p align="center">
-  <a href="https://github.com/ElementsProject/cln-application">
-    <img src="./.github/images/Dashboard.png" alt="Core Lightning Dashboard">
-  </a>
-  <h1 align="center">Core Lightning Application</h1>
-  <h3 align="center">
-    Run a Core Lightning application for your node. An official app by Blockstream. Powered by Core Lightning.
-    <br />
-    <br />
-    <div align="center">
-      <a href="https://twitter.com/Blockstream">
-        <img src="https://img.shields.io/twitter/follow/blockstream?style=social" style="height: 21px;"/>
-      </a>
-      <a href="https://marketplace.start9.com">
-        <img src="./.github/images/start9-badge-light.svg"/>
-      </a>
-      <a href="https://apps.umbrel.com/app/core-lightning">
-        <img src="./.github/images/umbrel-badge-light.svg" style="width: 130px;height: 21px;"/>
-      </a>
-    </div>
-  </h3>
+  <h1 align="center">SuperScalar Wallet</h1>
+  <p align="center">
+    A non-custodial Lightning wallet powered by <a href="https://superscalar.win">SuperScalar</a> channel factories.
+  </p>
 </p>
 
 ---
 
-# Prerequisites
-* Functioning and synced Bitcoin & Core lightning node.
-* Node.js, which can be downloaded [here](https://nodejs.org/en/download/)
-* Recommended Browsers: Chrome, Firefox, MS Edge
+## Overview
 
----
+SuperScalar Wallet is a web-based interface for managing Lightning channel factories on [Core Lightning](https://github.com/ElementsProject/lightning). It connects to the [SuperScalar CLN plugin](https://github.com/8144225309/superscalar-cln) to provide factory lifecycle management, channel visualization, and standard Lightning node operations.
 
-# Getting started
+SuperScalar enables multiple users to share a single on-chain UTXO for non-custodial Lightning channel access — no consensus changes required. For a detailed explanation of the protocol, visit [superscalar.win](https://superscalar.win).
 
-- ## Standalone
-  - ### Get latest release
-      ```
-      wget https://github.com/ElementsProject/cln-application/archive/refs/tags/v25.07.tar.gz
-      tar -xzf v25.07.tar.gz
-      ```
+## Features
 
-  - ### Dependency Installation and Compile
+- Factory creation, rotation, and cooperative close
+- Factory channel mapping and balance visualization
+- Per-epoch breach and revocation monitoring
+- Factory expiry tracking with laddering overview
+- Full Lightning node management (channels, payments, invoices, bookkeeping)
+- SQL query terminal for advanced node introspection
 
-    ```
-    cd cln-application-25.07
-    npm ci
-    npm run build
-    npm prune --omit=dev
-    ```
+## Prerequisites
 
-  - ### Environment Variables
-      This application accepts & depends upon these variables to be passed through environment:
+- Synced Bitcoin and Core Lightning node
+- [SuperScalar CLN plugin](https://github.com/8144225309/superscalar-cln) installed and active
+- [Node.js](https://nodejs.org/en/download/)
+- Recommended browsers: Chrome, Firefox, MS Edge
 
-      ```
-      # Required by entrypoint.sh script
-      - LIGHTNING_DATA_DIR: Path for core lightning (used by entrypoint.sh, default: ``)
-      - BITCOIN_NETWORK: Bitcoin network type (for entrypoint.sh; valid values: bitcoin/signet/testnet/regtest; default: `bitcoin`)
+## Getting Started
 
-      # cln-application Values
-      - APP_SINGLE_SIGN_ON: Flag to bypass application level authentication (valid values: true/false, default: false)
-      - APP_PROTOCOL: Protocol on which the application will be served (valid values: http/https, default: `http`)
-      - APP_HOST: Hostname/IP address of cln-application's container (default: `localhost`)
-      - APP_PORT: Port on which this application should be served (default: `2103`)
-      - APP_CONFIG_FILE: Path for cln-application's configuration file (default: `./config.json`)
-      - APP_LOG_FILE: Path for cln-application's log file (default: `./application-cln.log`)
-      - APP_MODE: Mode for logging and other settings (valid values: production/development/testing, default: `production`)
-      - APP_CONNECT: Choose how to connect to CLN (valid values: COMMANDO/REST, default: `COMMANDO`)
+### Standalone
 
-      # Core lightning Values
-      - LIGHTNING_HOST: IP address of Core lightning node (default: `localhost`)
-      - LIGHTNING_TOR_HOST: Tor Hidden Service url (default: ``)
-      - LIGHTNING_VARS_FILE: Full Path including the file name for connection auth with LIGHTNING_PUBKEY & LIGHTNING_RUNE (defult: `./.commando-env`)
+```bash
+git clone https://github.com/8144225309/superscalar-wallet.git
+cd superscalar-wallet
+npm ci
+npm run build
+npm prune --omit=dev
+npm run start
+```
 
-      # CLN Commando (WS) Values
-      - LIGHTNING_WS_PROTOCOL: Core lightning's web socket is serving on ws or serving via WSSProxy (valid values: ws/wss, default: `ws`)
-      - LIGHTNING_WS_HOST: Core lightning's IP address where commando can connect (default: `localhost`)
-      - LIGHTNING_WS_TOR_HOST: Core lightning's Tor address where commando can connect (default: ``)
-      - LIGHTNING_WS_PORT: Core lightning's websocket port (used by `COMMANDO` APP_CONNECT; with `bind-addr=ws:`/`wss-bind-addr` in CLN config; default: `5001`)
-      - LIGHTNING_WS_CLIENT_KEY_FILE: Client key file path including file name for websocket TLS authentication (used by `COMMANDO` APP_CONNECT and `wss` LIGHTNING_WS_PROTOCOL; default: `./client-key.pem`)
-      - LIGHTNING_WS_CLIENT_CERT_FILE: Client certificate file path including file name for websocket TLS authentication (used by `COMMANDO` APP_CONNECT and `wss` LIGHTNING_WS_PROTOCOL; default: `./client.pem`)
-      - LIGHTNING_WS_CA_CERT_FILE: CA certificate file path including file name for websocket TLS authentication (default: `./ca.pem`)
+### Docker
 
-      # CLN REST Values
-      - LIGHTNING_REST_PROTOCOL: Protocol on which REST is served (valid values: http/https, default: `https`)
-      - LIGHTNING_REST_HOST: IP address/hostname of Core Lightning REST interface (used if APP_CONNECT is `REST`, default: `localhost`)
-      - LIGHTNING_REST_TOR_HOST: Tor hidden service URL for Core Lightning REST interface (default: ``)
-      - LIGHTNING_REST_PORT: REST server port (used if APP_CONNECT is `REST`; default: `3010`)
-      - LIGHTNING_REST_CLIENT_KEY_FILE: Client key file path including file name for REST TLS authentication (default: `./client-key.pem`)
-      - LIGHTNING_REST_CLIENT_CERT_FILE: Client certificate file path including file name for REST TLS authentication (default: `./client.pem`)
-      - LIGHTNING_REST_CA_CERT_FILE: CA certificate file path including file name for REST TLS authentication (used by `REST` APP_CONNECT and `https` LIGHTNING_REST_PROTOCOL; default: `./ca.pem`)
+For Docker deployment with a remote Core Lightning node, see the [Docker Setup Guide](./.github/docs/Docker-Setup.md).
 
-      # CLN gRPC Values
-      - LIGHTNING_GRPC_HOST: IP address/hostname of Core Lightning GRPC interface (default: `localhost`)
-      - LIGHTNING_GRPC_TOR_HOST: Tor hidden service URL for Core Lightning GRPC interface (default: ``)
-      - LIGHTNING_GRPC_PORT: Core lightning's GRPC port (default: `9736`)
-      - LIGHTNING_GRPC_PROTO_PATH: URL to directory containing CLN gRPC protocol definitions (default: `https://github.com/ElementsProject/lightning/tree/master/cln-grpc/proto`)
-      - LIGHTNING_GRPC_CLIENT_KEY_FILE: Client key file path including file name for GRPC TLS authentication (used by `GRPC` APP_CONNECT; default: `./client-key.pem`)
-      - LIGHTNING_GRPC_CLIENT_CERT_FILE: Client certificate file path including file name for GRPC TLS authentication (used by `GRPC` APP_CONNECT; default: `./client.pem`)
-      - LIGHTNING_GRPC_CA_CERT_FILE: CA certificate file path including file name for GRPC TLS authentication (used by `GRPC` APP_CONNECT; default: `./ca.pem`)
-      ```
+### Configuration
 
-      Set these variables either via terminal OR by env.sh script OR by explicitly loading variables from .env files.
-      Important Note: Environment variables take precedence over config.json variables. Like `APP_SINGLE_SIGN_ON` will take higher precedence over 
-      `singleSignOn` from config.json.
+The application connects to Core Lightning via [Commando](https://docs.corelightning.org/reference/lightning-commando) (default) or REST. See [Environment Variables](#environment-variables) for connection options.
 
-  - ### Application Configuration
-      This is the default `config.json` file which is required by application's frontend. If the file `APP_CONFIG_FILE` is missing at the location, one like below will be auto created:
+Authentication uses [runes](https://docs.corelightning.org/reference/lightning-commando) for trustless, end-to-end encrypted communication. The `entrypoint.sh` script can auto-generate credentials for local installations, or they can be configured manually for remote nodes.
 
-      ```
-        {
-          "unit": "SATS",
-          "fiatUnit": "USD",
-          "appMode": "DARK",
-          "isLoading": false,
-          "error": null,
-          "singleSignOn": false,
-          "password": ""
-        }
-      ```
+## Environment Variables
 
-  - ### Commando Authentication
-      - This application utilizes [lnmessage](https://github.com/aaronbarnardsound/lnmessage) and [commando](https://docs.corelightning.org/reference/lightning-commando) for connecting with core lightning node. The connection is trustless and end-to-end encrypted. Commando manages authentication and authorization through runes, which can grant either full or fine-grained permissions. 
-      - The backend server reads `LIGHTNING_PUBKEY` & `LIGHTNING_RUNE` from the `LIGHTNING_VARS_FILE` file for this communication. 
-      - Values can either be set manually or script `entrypoint.sh` can be used to call `getinfo` and `createrune` methods and save values in `LIGHTNING_VARS_FILE`.
-      - `entrypoint.sh` can only run for the locally installed lightning. If `cln-application` is running remotely then pubkey and 
-      rune can be set manually.
-      - The script requires `socat` and `jq` to run successfully.
-      - Sample commando config should look like:
+<details>
+<summary>Click to expand</summary>
 
-        ```
-          LIGHTNING_PUBKEY="03d2d3b2...0f8303bfe"
-          LIGHTNING_RUNE="iv...4j"
-        ```
+```
+# Required by entrypoint.sh
+LIGHTNING_DATA_DIR     # Path for Core Lightning data
+BITCOIN_NETWORK        # bitcoin / signet / testnet / regtest (default: bitcoin)
 
-  - ### Start The Application
-      - Setup environment variables either via terminal OR by env.sh script OR by explicitly loading variables from .env files.
-      - Run `start` script for starting your application's server at port `APP_PORT`
+# Application
+APP_SINGLE_SIGN_ON     # Bypass app-level auth (default: false)
+APP_PROTOCOL           # http / https (default: http)
+APP_HOST               # Hostname (default: localhost)
+APP_PORT               # Port (default: 2103)
+APP_CONFIG_FILE        # Config file path (default: ./config.json)
+APP_LOG_FILE           # Log file path (default: ./application-cln.log)
+APP_MODE               # production / development / testing (default: production)
+APP_CONNECT            # COMMANDO / REST (default: COMMANDO)
 
-      ```
-        npm run start
-      ```
-- ## Docker
-  - For a minimal Docker setup to run the application with a remote Core Lightning node, see our [Docker Setup Guide](./.github/docs/Docker-Setup.md).
+# Core Lightning
+LIGHTNING_HOST         # CLN IP address (default: localhost)
+LIGHTNING_VARS_FILE    # Path to file with LIGHTNING_PUBKEY & LIGHTNING_RUNE
 
-- ## Stores/Marketplaces
-  - This application is also available on Umbrel App Store and Start9 OS with one click install.
+# Commando (WebSocket)
+LIGHTNING_WS_PORT      # WebSocket port (default: 5001)
 
----
+# REST
+LIGHTNING_REST_PORT    # REST server port (default: 3010)
+```
 
-# Contributing
+Environment variables take precedence over `config.json` values. Full variable reference available in the [upstream documentation](https://github.com/ElementsProject/cln-application).
 
-- We welcome and appreciate new contributions!
+</details>
 
-- If you're a developer looking to help but not sure where to begin, look for [these issues](https://github.com/ElementsProject/cln-application/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) that have specifically been marked as being friendly to new contributors.
+## Related Projects
 
-- If you're looking for a bigger challenge, before opening a pull request please [create an issue](https://github.com/ElementsProject/cln-application/issues/new/choose) to get feedback, discuss the best way to tackle the challenge, and to ensure that there's no duplication of work.
+| Project | Description |
+|---------|-------------|
+| [SuperScalar](https://github.com/8144225309/SuperScalar) | Reference implementation of the SuperScalar protocol |
+| [superscalar-cln](https://github.com/8144225309/superscalar-cln) | Core Lightning plugin for SuperScalar channel factories |
+| [superscalar-docs](https://github.com/8144225309/superscalar-docs) | Protocol documentation and visual guides |
+| [superscalar.win](https://superscalar.win) | SuperScalar explainer and documentation site |
 
-- Click [here](./.github/docs/Contributing.md) for instructions on how to run it in development mode.
+## Contributing
 
-- Follow the steps outlined in [troubleshooting](./.github/docs/Troubleshooting.md) to verify that your Commando connection is successfully established with your current environment setup.
+Contributions are welcome. Please [open an issue](https://github.com/8144225309/superscalar-wallet/issues/new) before submitting a pull request to discuss the approach.
 
----
+See [Contributing](./.github/docs/Contributing.md) for development setup and [Troubleshooting](./.github/docs/Troubleshooting.md) for connection debugging.
 
-# Acknowledgements
+## License
 
-- This app is inspired by the work done by [Umbrel lightning app](https://github.com/getumbrel/umbrel-lightning).
-
-- The backend api connects with core lightning via [lnmessage](https://github.com/aaronbarnardsound/lnmessage).
+This project is forked from [cln-application](https://github.com/ElementsProject/cln-application) by Blockstream. See [LICENSE](./LICENSE) for details.

--- a/README.md
+++ b/README.md
@@ -24,9 +24,10 @@ SuperScalar enables multiple users to share a single on-chain UTXO for non-custo
 
 ## Prerequisites
 
-- Synced Bitcoin and Core Lightning node
+- [Core Lightning (bLIP-56 fork)](https://github.com/8144225309/lightning/tree/blip-56) — the `blip-56` branch with pluggable channel factory support
 - [SuperScalar CLN plugin](https://github.com/8144225309/superscalar-cln) installed and active
-- [Node.js](https://nodejs.org/en/download/)
+- Bitcoin Core 28+, synced to network
+- [Node.js](https://nodejs.org/en/download/) 16+
 - Recommended browsers: Chrome, Firefox, MS Edge
 
 ## Getting Started
@@ -92,7 +93,8 @@ Environment variables take precedence over `config.json` values. Full variable r
 | Project | Description |
 |---------|-------------|
 | [SuperScalar](https://github.com/8144225309/SuperScalar) | Reference implementation of the SuperScalar protocol |
-| [superscalar-cln](https://github.com/8144225309/superscalar-cln) | Core Lightning plugin for SuperScalar channel factories |
+| [superscalar-cln](https://github.com/8144225309/superscalar-cln) | SuperScalar channel factory plugin for Core Lightning (bLIP-56) |
+| [lightning (bLIP-56 fork)](https://github.com/8144225309/lightning/tree/blip-56) | Core Lightning fork with pluggable channel factory support |
 | [superscalar-docs](https://github.com/8144225309/superscalar-docs) | Protocol documentation and visual guides |
 | [superscalar.win](https://superscalar.win) | SuperScalar explainer and documentation site |
 

--- a/README.upstream.md
+++ b/README.upstream.md
@@ -1,0 +1,168 @@
+<p align="center">
+  <a href="https://github.com/ElementsProject/cln-application">
+    <img src="./.github/images/Dashboard.png" alt="Core Lightning Dashboard">
+  </a>
+  <h1 align="center">Core Lightning Application</h1>
+  <h3 align="center">
+    Run a Core Lightning application for your node. An official app by Blockstream. Powered by Core Lightning.
+    <br />
+    <br />
+    <div align="center">
+      <a href="https://twitter.com/Blockstream">
+        <img src="https://img.shields.io/twitter/follow/blockstream?style=social" style="height: 21px;"/>
+      </a>
+      <a href="https://marketplace.start9.com">
+        <img src="./.github/images/start9-badge-light.svg"/>
+      </a>
+      <a href="https://apps.umbrel.com/app/core-lightning">
+        <img src="./.github/images/umbrel-badge-light.svg" style="width: 130px;height: 21px;"/>
+      </a>
+    </div>
+  </h3>
+</p>
+
+---
+
+# Prerequisites
+* Functioning and synced Bitcoin & Core lightning node.
+* Node.js, which can be downloaded [here](https://nodejs.org/en/download/)
+* Recommended Browsers: Chrome, Firefox, MS Edge
+
+---
+
+# Getting started
+
+- ## Standalone
+  - ### Get latest release
+      ```
+      wget https://github.com/ElementsProject/cln-application/archive/refs/tags/v25.07.tar.gz
+      tar -xzf v25.07.tar.gz
+      ```
+
+  - ### Dependency Installation and Compile
+
+    ```
+    cd cln-application-25.07
+    npm ci
+    npm run build
+    npm prune --omit=dev
+    ```
+
+  - ### Environment Variables
+      This application accepts & depends upon these variables to be passed through environment:
+
+      ```
+      # Required by entrypoint.sh script
+      - LIGHTNING_DATA_DIR: Path for core lightning (used by entrypoint.sh, default: ``)
+      - BITCOIN_NETWORK: Bitcoin network type (for entrypoint.sh; valid values: bitcoin/signet/testnet/regtest; default: `bitcoin`)
+
+      # cln-application Values
+      - APP_SINGLE_SIGN_ON: Flag to bypass application level authentication (valid values: true/false, default: false)
+      - APP_PROTOCOL: Protocol on which the application will be served (valid values: http/https, default: `http`)
+      - APP_HOST: Hostname/IP address of cln-application's container (default: `localhost`)
+      - APP_PORT: Port on which this application should be served (default: `2103`)
+      - APP_CONFIG_FILE: Path for cln-application's configuration file (default: `./config.json`)
+      - APP_LOG_FILE: Path for cln-application's log file (default: `./application-cln.log`)
+      - APP_MODE: Mode for logging and other settings (valid values: production/development/testing, default: `production`)
+      - APP_CONNECT: Choose how to connect to CLN (valid values: COMMANDO/REST, default: `COMMANDO`)
+
+      # Core lightning Values
+      - LIGHTNING_HOST: IP address of Core lightning node (default: `localhost`)
+      - LIGHTNING_TOR_HOST: Tor Hidden Service url (default: ``)
+      - LIGHTNING_VARS_FILE: Full Path including the file name for connection auth with LIGHTNING_PUBKEY & LIGHTNING_RUNE (defult: `./.commando-env`)
+
+      # CLN Commando (WS) Values
+      - LIGHTNING_WS_PROTOCOL: Core lightning's web socket is serving on ws or serving via WSSProxy (valid values: ws/wss, default: `ws`)
+      - LIGHTNING_WS_HOST: Core lightning's IP address where commando can connect (default: `localhost`)
+      - LIGHTNING_WS_TOR_HOST: Core lightning's Tor address where commando can connect (default: ``)
+      - LIGHTNING_WS_PORT: Core lightning's websocket port (used by `COMMANDO` APP_CONNECT; with `bind-addr=ws:`/`wss-bind-addr` in CLN config; default: `5001`)
+      - LIGHTNING_WS_CLIENT_KEY_FILE: Client key file path including file name for websocket TLS authentication (used by `COMMANDO` APP_CONNECT and `wss` LIGHTNING_WS_PROTOCOL; default: `./client-key.pem`)
+      - LIGHTNING_WS_CLIENT_CERT_FILE: Client certificate file path including file name for websocket TLS authentication (used by `COMMANDO` APP_CONNECT and `wss` LIGHTNING_WS_PROTOCOL; default: `./client.pem`)
+      - LIGHTNING_WS_CA_CERT_FILE: CA certificate file path including file name for websocket TLS authentication (default: `./ca.pem`)
+
+      # CLN REST Values
+      - LIGHTNING_REST_PROTOCOL: Protocol on which REST is served (valid values: http/https, default: `https`)
+      - LIGHTNING_REST_HOST: IP address/hostname of Core Lightning REST interface (used if APP_CONNECT is `REST`, default: `localhost`)
+      - LIGHTNING_REST_TOR_HOST: Tor hidden service URL for Core Lightning REST interface (default: ``)
+      - LIGHTNING_REST_PORT: REST server port (used if APP_CONNECT is `REST`; default: `3010`)
+      - LIGHTNING_REST_CLIENT_KEY_FILE: Client key file path including file name for REST TLS authentication (default: `./client-key.pem`)
+      - LIGHTNING_REST_CLIENT_CERT_FILE: Client certificate file path including file name for REST TLS authentication (default: `./client.pem`)
+      - LIGHTNING_REST_CA_CERT_FILE: CA certificate file path including file name for REST TLS authentication (used by `REST` APP_CONNECT and `https` LIGHTNING_REST_PROTOCOL; default: `./ca.pem`)
+
+      # CLN gRPC Values
+      - LIGHTNING_GRPC_HOST: IP address/hostname of Core Lightning GRPC interface (default: `localhost`)
+      - LIGHTNING_GRPC_TOR_HOST: Tor hidden service URL for Core Lightning GRPC interface (default: ``)
+      - LIGHTNING_GRPC_PORT: Core lightning's GRPC port (default: `9736`)
+      - LIGHTNING_GRPC_PROTO_PATH: URL to directory containing CLN gRPC protocol definitions (default: `https://github.com/ElementsProject/lightning/tree/master/cln-grpc/proto`)
+      - LIGHTNING_GRPC_CLIENT_KEY_FILE: Client key file path including file name for GRPC TLS authentication (used by `GRPC` APP_CONNECT; default: `./client-key.pem`)
+      - LIGHTNING_GRPC_CLIENT_CERT_FILE: Client certificate file path including file name for GRPC TLS authentication (used by `GRPC` APP_CONNECT; default: `./client.pem`)
+      - LIGHTNING_GRPC_CA_CERT_FILE: CA certificate file path including file name for GRPC TLS authentication (used by `GRPC` APP_CONNECT; default: `./ca.pem`)
+      ```
+
+      Set these variables either via terminal OR by env.sh script OR by explicitly loading variables from .env files.
+      Important Note: Environment variables take precedence over config.json variables. Like `APP_SINGLE_SIGN_ON` will take higher precedence over 
+      `singleSignOn` from config.json.
+
+  - ### Application Configuration
+      This is the default `config.json` file which is required by application's frontend. If the file `APP_CONFIG_FILE` is missing at the location, one like below will be auto created:
+
+      ```
+        {
+          "unit": "SATS",
+          "fiatUnit": "USD",
+          "appMode": "DARK",
+          "isLoading": false,
+          "error": null,
+          "singleSignOn": false,
+          "password": ""
+        }
+      ```
+
+  - ### Commando Authentication
+      - This application utilizes [lnmessage](https://github.com/aaronbarnardsound/lnmessage) and [commando](https://docs.corelightning.org/reference/lightning-commando) for connecting with core lightning node. The connection is trustless and end-to-end encrypted. Commando manages authentication and authorization through runes, which can grant either full or fine-grained permissions. 
+      - The backend server reads `LIGHTNING_PUBKEY` & `LIGHTNING_RUNE` from the `LIGHTNING_VARS_FILE` file for this communication. 
+      - Values can either be set manually or script `entrypoint.sh` can be used to call `getinfo` and `createrune` methods and save values in `LIGHTNING_VARS_FILE`.
+      - `entrypoint.sh` can only run for the locally installed lightning. If `cln-application` is running remotely then pubkey and 
+      rune can be set manually.
+      - The script requires `socat` and `jq` to run successfully.
+      - Sample commando config should look like:
+
+        ```
+          LIGHTNING_PUBKEY="03d2d3b2...0f8303bfe"
+          LIGHTNING_RUNE="iv...4j"
+        ```
+
+  - ### Start The Application
+      - Setup environment variables either via terminal OR by env.sh script OR by explicitly loading variables from .env files.
+      - Run `start` script for starting your application's server at port `APP_PORT`
+
+      ```
+        npm run start
+      ```
+- ## Docker
+  - For a minimal Docker setup to run the application with a remote Core Lightning node, see our [Docker Setup Guide](./.github/docs/Docker-Setup.md).
+
+- ## Stores/Marketplaces
+  - This application is also available on Umbrel App Store and Start9 OS with one click install.
+
+---
+
+# Contributing
+
+- We welcome and appreciate new contributions!
+
+- If you're a developer looking to help but not sure where to begin, look for [these issues](https://github.com/ElementsProject/cln-application/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) that have specifically been marked as being friendly to new contributors.
+
+- If you're looking for a bigger challenge, before opening a pull request please [create an issue](https://github.com/ElementsProject/cln-application/issues/new/choose) to get feedback, discuss the best way to tackle the challenge, and to ensure that there's no duplication of work.
+
+- Click [here](./.github/docs/Contributing.md) for instructions on how to run it in development mode.
+
+- Follow the steps outlined in [troubleshooting](./.github/docs/Troubleshooting.md) to verify that your Commando connection is successfully established with your current environment setup.
+
+---
+
+# Acknowledgements
+
+- This app is inspired by the work done by [Umbrel lightning app](https://github.com/getumbrel/umbrel-lightning).
+
+- The backend api connects with core lightning via [lnmessage](https://github.com/aaronbarnardsound/lnmessage).

--- a/apps/frontend/src/components/factories/BreachStatus/BreachStatus.scss
+++ b/apps/frontend/src/components/factories/BreachStatus/BreachStatus.scss
@@ -1,0 +1,1 @@
+@use '../../../styles/constants' as *;

--- a/apps/frontend/src/components/factories/BreachStatus/BreachStatus.tsx
+++ b/apps/frontend/src/components/factories/BreachStatus/BreachStatus.tsx
@@ -1,0 +1,41 @@
+import './BreachStatus.scss';
+import { Card, ListGroup, Alert } from 'react-bootstrap';
+import { useSelector } from 'react-redux';
+import { selectFactories, selectFactoriesLoading } from '../../../store/factoriesSelectors';
+
+const BreachStatus = () => {
+  const factories = useSelector(selectFactories);
+  const isLoading = useSelector(selectFactoriesLoading);
+
+  const breachedFactories = factories.filter(f => f.n_breach_epochs > 0);
+
+  return (
+    <Card className='inner-box-shadow mb-4' data-testid='breach-status'>
+      <Card.Body className='px-4 pt-3 pb-2'>
+        <div className='fs-18px fw-bold text-dark mb-2'>Breach Status</div>
+        {isLoading ? null :
+          breachedFactories.length === 0 ? (
+            <div className='fs-7 text-light py-2'>No breaches detected</div>
+          ) : (
+            <ListGroup variant='flush'>
+              {breachedFactories.map(factory => (
+                <ListGroup.Item key={factory.instance_id} className='px-0 py-2'>
+                  <div className='d-flex justify-content-between align-items-center'>
+                    <span className='fs-7 text-dark'>
+                      {factory.instance_id.substring(0, 16)}...
+                    </span>
+                    <Alert variant='danger' className='py-0 px-2 mb-0 fs-7'>
+                      {factory.n_breach_epochs} breach epoch{factory.n_breach_epochs > 1 ? 's' : ''}
+                    </Alert>
+                  </div>
+                </ListGroup.Item>
+              ))}
+            </ListGroup>
+          )
+        }
+      </Card.Body>
+    </Card>
+  );
+};
+
+export default BreachStatus;

--- a/apps/frontend/src/components/factories/CeremonyProgress/CeremonyProgress.scss
+++ b/apps/frontend/src/components/factories/CeremonyProgress/CeremonyProgress.scss
@@ -1,0 +1,53 @@
+@use '../../../styles/constants' as *;
+
+.ceremony-progress {
+  .ceremony-steps {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+  }
+
+  .ceremony-dot {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    position: relative;
+
+    &::before {
+      content: '';
+      width: 12px;
+      height: 12px;
+      border-radius: 50%;
+      display: block;
+      margin-bottom: 4px;
+    }
+
+    &.active::before {
+      background-color: $primary;
+      box-shadow: 0 0 0 3px rgba($primary, 0.3);
+    }
+
+    &.completed::before {
+      background-color: $success;
+    }
+
+    &.pending::before {
+      background-color: $gray-400;
+    }
+  }
+
+  .ceremony-line {
+    width: 20px;
+    height: 2px;
+    background-color: $gray-400;
+    margin-bottom: 16px;
+
+    &.completed {
+      background-color: $success;
+    }
+  }
+
+  .ceremony-label {
+    white-space: nowrap;
+    color: $gray-600;
+  }
+}

--- a/apps/frontend/src/components/factories/CeremonyProgress/CeremonyProgress.tsx
+++ b/apps/frontend/src/components/factories/CeremonyProgress/CeremonyProgress.tsx
@@ -1,0 +1,81 @@
+import './CeremonyProgress.scss';
+import { FactoryCeremony } from '../../../types/factories.type';
+
+type CeremonyProgressProps = {
+  ceremony: FactoryCeremony;
+};
+
+const CREATION_STEPS = [
+  FactoryCeremony.IDLE,
+  FactoryCeremony.PROPOSED,
+  FactoryCeremony.NONCES_COLLECTED,
+  FactoryCeremony.PSIGS_COLLECTED,
+  FactoryCeremony.COMPLETE,
+];
+
+const ROTATION_STEPS = [
+  FactoryCeremony.ROTATING,
+  FactoryCeremony.ROTATE_COMPLETE,
+  FactoryCeremony.REVOKED,
+];
+
+const stepLabel = (step: FactoryCeremony) => {
+  switch (step) {
+    case FactoryCeremony.IDLE: return 'Idle';
+    case FactoryCeremony.PROPOSED: return 'Proposed';
+    case FactoryCeremony.NONCES_COLLECTED: return 'Nonces';
+    case FactoryCeremony.PSIGS_COLLECTED: return 'PSigs';
+    case FactoryCeremony.COMPLETE: return 'Complete';
+    case FactoryCeremony.ROTATING: return 'Rotating';
+    case FactoryCeremony.ROTATE_COMPLETE: return 'Rotated';
+    case FactoryCeremony.REVOKED: return 'Revoked';
+    case FactoryCeremony.FAILED: return 'Failed';
+    default: return step;
+  }
+};
+
+const CeremonyProgress = ({ ceremony }: CeremonyProgressProps) => {
+  const isRotation = ROTATION_STEPS.includes(ceremony);
+  const isFailed = ceremony === FactoryCeremony.FAILED;
+  const steps = isRotation ? ROTATION_STEPS : CREATION_STEPS;
+  const currentIdx = steps.indexOf(ceremony);
+
+  if (isFailed) {
+    return (
+      <div className='ceremony-progress mb-2'>
+        <div className='fs-7 text-light mb-1'>Ceremony</div>
+        <span className='badge bg-danger'>Failed</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className='ceremony-progress mb-2'>
+      <div className='fs-7 text-light mb-1'>Ceremony</div>
+      <div className='d-flex align-items-center ceremony-steps'>
+        {steps.map((step, idx) => {
+          const isActive = idx === currentIdx;
+          const isCompleted = idx < currentIdx;
+          return (
+            <div key={step} className='d-flex align-items-center'>
+              {idx > 0 && (
+                <div className={'ceremony-line ' + (isCompleted ? 'completed' : '')} />
+              )}
+              <div
+                className={
+                  'ceremony-dot ' +
+                  (isActive ? 'active' : isCompleted ? 'completed' : 'pending')
+                }
+                title={stepLabel(step)}
+              >
+                <span className='ceremony-label fs-8'>{stepLabel(step)}</span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default CeremonyProgress;

--- a/apps/frontend/src/components/factories/ExpiryWarnings/ExpiryWarnings.scss
+++ b/apps/frontend/src/components/factories/ExpiryWarnings/ExpiryWarnings.scss
@@ -1,0 +1,5 @@
+@use '../../../styles/constants' as *;
+
+.expiry-progress {
+  height: 6px;
+}

--- a/apps/frontend/src/components/factories/ExpiryWarnings/ExpiryWarnings.tsx
+++ b/apps/frontend/src/components/factories/ExpiryWarnings/ExpiryWarnings.tsx
@@ -1,0 +1,70 @@
+import './ExpiryWarnings.scss';
+import { Card, ListGroup, ProgressBar } from 'react-bootstrap';
+import { useSelector } from 'react-redux';
+import { selectNodeInfo } from '../../../store/rootSelectors';
+import { selectFactories, selectFactoriesLoading } from '../../../store/factoriesSelectors';
+import { FactoryLifecycle } from '../../../types/factories.type';
+
+const ExpiryWarnings = () => {
+  const nodeInfo = useSelector(selectNodeInfo);
+  const factories = useSelector(selectFactories);
+  const isLoading = useSelector(selectFactoriesLoading);
+
+  const currentBlock = nodeInfo.blockheight || 0;
+  const activeFactories = factories
+    .filter(f => f.lifecycle !== FactoryLifecycle.EXPIRED && f.expiry_block > 0)
+    .sort((a, b) => a.expiry_block - b.expiry_block);
+
+  const getWarningLevel = (blocksRemaining: number) => {
+    if (blocksRemaining <= 144) return 'danger';   // ~1 day
+    if (blocksRemaining <= 432) return 'warning';   // ~3 days
+    return 'success';
+  };
+
+  const getProgress = (factory: typeof activeFactories[0]) => {
+    const total = factory.expiry_block - factory.creation_block;
+    const elapsed = currentBlock - factory.creation_block;
+    if (total <= 0) return 100;
+    return Math.min(100, Math.max(0, (elapsed / total) * 100));
+  };
+
+  return (
+    <Card className='inner-box-shadow mb-4' data-testid='expiry-warnings'>
+      <Card.Body className='px-4 pt-3 pb-2'>
+        <div className='fs-18px fw-bold text-dark mb-2'>Factory Expiry</div>
+        {isLoading ? null :
+          activeFactories.length === 0 ? (
+            <div className='fs-7 text-light py-2'>No active factories</div>
+          ) : (
+            <ListGroup variant='flush'>
+              {activeFactories.map(factory => {
+                const blocksRemaining = factory.expiry_block - currentBlock;
+                const level = getWarningLevel(blocksRemaining);
+                const progress = getProgress(factory);
+                return (
+                  <ListGroup.Item key={factory.instance_id} className='px-0 py-2'>
+                    <div className='d-flex justify-content-between align-items-center mb-1'>
+                      <span className='fs-7 text-dark'>
+                        {factory.instance_id.substring(0, 12)}...
+                      </span>
+                      <span className={`fs-7 fw-bold text-${level}`}>
+                        {blocksRemaining > 0 ? `${blocksRemaining} blocks` : 'Expired'}
+                      </span>
+                    </div>
+                    <ProgressBar
+                      now={progress}
+                      variant={level}
+                      className='expiry-progress'
+                    />
+                  </ListGroup.Item>
+                );
+              })}
+            </ListGroup>
+          )
+        }
+      </Card.Body>
+    </Card>
+  );
+};
+
+export default ExpiryWarnings;

--- a/apps/frontend/src/components/factories/FactoriesHome/FactoriesHome.scss
+++ b/apps/frontend/src/components/factories/FactoriesHome/FactoriesHome.scss
@@ -1,0 +1,1 @@
+@use '../../../styles/constants' as *;

--- a/apps/frontend/src/components/factories/FactoriesHome/FactoriesHome.tsx
+++ b/apps/frontend/src/components/factories/FactoriesHome/FactoriesHome.tsx
@@ -1,0 +1,54 @@
+import './FactoriesHome.scss';
+import { Row, Col } from 'react-bootstrap';
+import Header from '../../ui/Header/Header';
+import { useSelector } from 'react-redux';
+import { useInjectReducer } from '../../../hooks/use-injectreducer';
+import factoriesReducer from '../../../store/factoriesSlice';
+import { selectNodeInfo } from '../../../store/rootSelectors';
+import FactoriesOverview from '../FactoriesOverview/FactoriesOverview';
+import FactoryListCard from '../FactoryListCard/FactoryListCard';
+import ExpiryWarnings from '../ExpiryWarnings/ExpiryWarnings';
+import BreachStatus from '../BreachStatus/BreachStatus';
+import LadderingTimeline from '../LadderingTimeline/LadderingTimeline';
+
+function FactoriesHome() {
+  useInjectReducer('factories', factoriesReducer);
+  const nodeInfo = useSelector(selectNodeInfo);
+
+  if (nodeInfo.error) {
+    return (
+      <Row className='message invalid mt-10'>
+        <Col xs={12} className='d-flex align-items-center justify-content-center'>
+          {nodeInfo.error}
+        </Col>
+      </Row>
+    );
+  }
+
+  return (
+    <div data-testid='factories-container'>
+      <Header />
+      <Row>
+        <Col className='mx-1'>
+          <FactoriesOverview />
+        </Col>
+      </Row>
+      <Row className='px-3'>
+        <Col xs={12} lg={8} className='cards-container'>
+          <FactoryListCard />
+        </Col>
+        <Col xs={12} lg={4} className='cards-container d-flex flex-column'>
+          <ExpiryWarnings />
+          <BreachStatus />
+        </Col>
+      </Row>
+      <Row className='px-3'>
+        <Col xs={12} className='cards-container'>
+          <LadderingTimeline />
+        </Col>
+      </Row>
+    </div>
+  );
+}
+
+export default FactoriesHome;

--- a/apps/frontend/src/components/factories/FactoriesOverview/FactoriesOverview.scss
+++ b/apps/frontend/src/components/factories/FactoriesOverview/FactoriesOverview.scss
@@ -1,0 +1,1 @@
+@use '../../../styles/constants' as *;

--- a/apps/frontend/src/components/factories/FactoriesOverview/FactoriesOverview.tsx
+++ b/apps/frontend/src/components/factories/FactoriesOverview/FactoriesOverview.tsx
@@ -1,0 +1,96 @@
+import { useEffect } from 'react';
+import { motion, useMotionValue, useTransform, animate } from 'framer-motion';
+import { Card, Col, Row, Spinner, Alert } from 'react-bootstrap';
+import { COUNTUP_DURATION } from '../../../utilities/constants';
+import { useSelector } from 'react-redux';
+import { selectIsAuthenticated } from '../../../store/rootSelectors';
+import { selectFactoryCounts, selectFactoriesLoading, selectFactoriesError } from '../../../store/factoriesSelectors';
+import { FactorySVG } from '../../../svgs/Factory';
+
+const FactoriesOverview = () => {
+  const isAuthenticated = useSelector(selectIsAuthenticated);
+  const counts = useSelector(selectFactoryCounts);
+  const isLoading = useSelector(selectFactoriesLoading);
+  const error = useSelector(selectFactoriesError);
+
+  const countTotal: any = useMotionValue(0);
+  const roundedTotal: any = useTransform(countTotal, Math.round);
+  const countActive: any = useMotionValue(0);
+  const roundedActive: any = useTransform(countActive, Math.round);
+
+  useEffect(() => {
+    const anim = animate(countTotal, counts.total, { duration: COUNTUP_DURATION });
+    return anim.stop;
+  }, [counts.total, countTotal]);
+
+  useEffect(() => {
+    const anim = animate(countActive, counts.active, { duration: COUNTUP_DURATION });
+    return anim.stop;
+  }, [counts.active, countActive]);
+
+  return (
+    <Row className='mx-1 align-items-stretch'>
+      <Col xs={12} lg={3} className='d-lg-flex d-xl-flex mb-4'>
+        <Card className='card overview-balance-card w-100' data-testid='factories-total-card'>
+          <Card.Body className='d-flex align-items-center'>
+            <Row className='flex-fill'>
+              <Col xs={8} data-testid='factories-total-col'>
+                <div className='fs-6 fw-bold'>Total Factories</div>
+                {isAuthenticated && isLoading ?
+                  <Spinner animation='grow' variant='secondary' /> :
+                  error ?
+                    <Alert className='py-0 px-1 fs-7' variant='danger'>{error}</Alert> :
+                    <motion.div className='fs-4 fw-bold text-dark-primary'>{roundedTotal}</motion.div>
+                }
+              </Col>
+              <Col xs={4} className='d-flex align-items-center justify-content-end'>
+                <FactorySVG />
+              </Col>
+            </Row>
+          </Card.Body>
+        </Card>
+      </Col>
+      <Col xs={12} lg={9} className='mb-4'>
+        <Card className='inner-box-shadow h-100' data-testid='factories-counts-card'>
+          <Card.Body className='px-4'>
+            <Row className='h-100'>
+              <Col xs={6} md={3} className='d-flex align-items-center justify-content-start'>
+                <div>
+                  <div className='text-light-white'>Active</div>
+                  <div className='fs-4 fw-bold text-dark-primary'>
+                    {isAuthenticated && isLoading ?
+                      <Spinner animation='grow' variant='primary' /> :
+                      error ?
+                        <Alert className='py-0 px-1 fs-7' variant='danger'>{error}</Alert> :
+                        <motion.div>{roundedActive}</motion.div>
+                    }
+                  </div>
+                </div>
+              </Col>
+              <Col xs={6} md={3} className='d-flex align-items-center justify-content-start'>
+                <div>
+                  <div className='text-light-white'>Initializing</div>
+                  <div className='fs-4 fw-bold text-dark-primary'>{counts.init}</div>
+                </div>
+              </Col>
+              <Col xs={6} md={3} className='d-flex align-items-center justify-content-start'>
+                <div>
+                  <div className='text-light-white'>Dying</div>
+                  <div className='fs-4 fw-bold text-warning'>{counts.dying}</div>
+                </div>
+              </Col>
+              <Col xs={6} md={3} className='d-flex align-items-center justify-content-start'>
+                <div>
+                  <div className='text-light-white'>Expired</div>
+                  <div className='fs-4 fw-bold text-danger'>{counts.expired}</div>
+                </div>
+              </Col>
+            </Row>
+          </Card.Body>
+        </Card>
+      </Col>
+    </Row>
+  );
+};
+
+export default FactoriesOverview;

--- a/apps/frontend/src/components/factories/FactoryCreate/FactoryCreate.scss
+++ b/apps/frontend/src/components/factories/FactoryCreate/FactoryCreate.scss
@@ -1,0 +1,1 @@
+@use '../../../styles/constants' as *;

--- a/apps/frontend/src/components/factories/FactoryCreate/FactoryCreate.tsx
+++ b/apps/frontend/src/components/factories/FactoryCreate/FactoryCreate.tsx
@@ -1,0 +1,110 @@
+import './FactoryCreate.scss';
+import { useState } from 'react';
+import { Card, Row, Col, Form, Spinner } from 'react-bootstrap';
+import { CallStatus, CLEAR_STATUS_ALERT_DELAY } from '../../../utilities/constants';
+import { FactoriesService } from '../../../services/http.service';
+import StatusAlert from '../../shared/StatusAlert/StatusAlert';
+
+type FactoryCreateProps = {
+  onClose: () => void;
+};
+
+const FactoryCreate = ({ onClose }: FactoryCreateProps) => {
+  const [fundingSats, setFundingSats] = useState('');
+  const [clientIds, setClientIds] = useState('');
+  const [responseStatus, setResponseStatus] = useState(CallStatus.NONE);
+  const [responseMessage, setResponseMessage] = useState('');
+
+  const handleCreate = async () => {
+    const amount = parseInt(fundingSats, 10);
+    if (!amount || amount <= 0) {
+      setResponseStatus(CallStatus.ERROR);
+      setResponseMessage('Funding amount must be greater than 0');
+      return;
+    }
+
+    const clients = clientIds
+      .split('\n')
+      .map(id => id.trim())
+      .filter(id => id.length > 0);
+
+    if (clients.length === 0) {
+      setResponseStatus(CallStatus.ERROR);
+      setResponseMessage('At least one client node ID is required');
+      return;
+    }
+
+    setResponseStatus(CallStatus.PENDING);
+    setResponseMessage('Creating factory...');
+
+    try {
+      const res = await FactoriesService.createFactory(amount, clients);
+      setResponseStatus(CallStatus.SUCCESS);
+      setResponseMessage(`Factory created: ${res.instance_id.substring(0, 16)}...`);
+      FactoriesService.fetchFactoriesData();
+      setTimeout(() => {
+        onClose();
+      }, CLEAR_STATUS_ALERT_DELAY);
+    } catch (err: any) {
+      setResponseStatus(CallStatus.ERROR);
+      setResponseMessage(typeof err === 'string' ? err : err.message || 'Factory creation failed');
+    }
+  };
+
+  return (
+    <Card className='h-100 d-flex align-items-stretch px-4 pt-4 pb-3' data-testid='factory-create'>
+      <Card.Header className='px-1 pb-2 p-0 d-flex justify-content-between align-items-center'>
+        <span className='fs-18px fw-bold text-dark'>Create Factory</span>
+        <button className='btn btn-sm btn-outline-secondary btn-rounded' onClick={onClose}>Cancel</button>
+      </Card.Header>
+      <Card.Body className='py-2 px-1'>
+        <Form>
+          <Form.Group className='mb-3'>
+            <Form.Label className='fs-7 text-light'>Funding Amount (sats)</Form.Label>
+            <Form.Control
+              type='number'
+              placeholder='100000'
+              value={fundingSats}
+              onChange={(e) => setFundingSats(e.target.value)}
+              disabled={responseStatus === CallStatus.PENDING}
+              data-testid='factory-create-amount'
+              autoFocus
+            />
+          </Form.Group>
+          <Form.Group className='mb-3'>
+            <Form.Label className='fs-7 text-light'>Client Node IDs (one per line)</Form.Label>
+            <Form.Control
+              as='textarea'
+              rows={4}
+              placeholder={'03abc123...def456\n02xyz789...ghi012'}
+              value={clientIds}
+              onChange={(e) => setClientIds(e.target.value)}
+              disabled={responseStatus === CallStatus.PENDING}
+              data-testid='factory-create-clients'
+              className='fs-7'
+            />
+          </Form.Group>
+        </Form>
+
+        {responseStatus !== CallStatus.NONE && (
+          <StatusAlert responseStatus={responseStatus} responseMessage={responseMessage} />
+        )}
+      </Card.Body>
+      <Card.Footer className='d-flex justify-content-center'>
+        <button
+          className='btn-rounded bg-primary'
+          onClick={handleCreate}
+          disabled={responseStatus === CallStatus.PENDING}
+          data-testid='button-submit-create-factory'
+        >
+          {responseStatus === CallStatus.PENDING ? (
+            <Spinner animation='border' size='sm' className='me-2' />
+          ) : null}
+          Create Factory
+        </button>
+      </Card.Footer>
+    </Card>
+  );
+};
+
+export default FactoryCreate;

--- a/apps/frontend/src/components/factories/FactoryDetail/FactoryDetail.scss
+++ b/apps/frontend/src/components/factories/FactoryDetail/FactoryDetail.scss
@@ -1,0 +1,9 @@
+@use '../../../styles/constants' as *;
+
+.factory-detail-scroll {
+  overflow-y: auto;
+}
+
+.cursor-pointer {
+  cursor: pointer;
+}

--- a/apps/frontend/src/components/factories/FactoryDetail/FactoryDetail.tsx
+++ b/apps/frontend/src/components/factories/FactoryDetail/FactoryDetail.tsx
@@ -1,0 +1,258 @@
+import './FactoryDetail.scss';
+import { useState } from 'react';
+import { Card, Row, Col, ListGroup, Alert, Spinner, OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { CallStatus, CLEAR_STATUS_ALERT_DELAY } from '../../../utilities/constants';
+import { Factory, FactoryLifecycle, FactoryCeremony } from '../../../types/factories.type';
+import { FactoriesService } from '../../../services/http.service';
+import StatusAlert from '../../shared/StatusAlert/StatusAlert';
+import { copyTextToClipboard } from '../../../utilities/data-formatters';
+import CeremonyProgress from '../CeremonyProgress/CeremonyProgress';
+
+type FactoryDetailProps = {
+  factory: Factory;
+  onClose: () => void;
+};
+
+const FactoryDetail = ({ factory, onClose }: FactoryDetailProps) => {
+  const [responseStatus, setResponseStatus] = useState(CallStatus.NONE);
+  const [responseMessage, setResponseMessage] = useState('');
+
+  const resetStatus = () => {
+    setTimeout(() => {
+      setResponseStatus(CallStatus.NONE);
+      setResponseMessage('');
+    }, CLEAR_STATUS_ALERT_DELAY);
+  };
+
+  const handleRotate = async () => {
+    setResponseStatus(CallStatus.PENDING);
+    setResponseMessage('Rotating factory...');
+    try {
+      const res = await FactoriesService.rotateFactory(factory.instance_id);
+      setResponseStatus(CallStatus.SUCCESS);
+      setResponseMessage(`Rotated: epoch ${res.old_epoch} -> ${res.new_epoch}`);
+      FactoriesService.fetchFactoriesData();
+      resetStatus();
+    } catch (err: any) {
+      setResponseStatus(CallStatus.ERROR);
+      setResponseMessage(typeof err === 'string' ? err : err.message || 'Rotation failed');
+      resetStatus();
+    }
+  };
+
+  const handleClose = async () => {
+    setResponseStatus(CallStatus.PENDING);
+    setResponseMessage('Closing factory...');
+    try {
+      const res = await FactoriesService.closeFactory(factory.instance_id);
+      setResponseStatus(CallStatus.SUCCESS);
+      setResponseMessage(`Close initiated: ${res.status}`);
+      FactoriesService.fetchFactoriesData();
+      resetStatus();
+    } catch (err: any) {
+      setResponseStatus(CallStatus.ERROR);
+      setResponseMessage(typeof err === 'string' ? err : err.message || 'Close failed');
+      resetStatus();
+    }
+  };
+
+  const handleForceClose = async () => {
+    setResponseStatus(CallStatus.PENDING);
+    setResponseMessage('Force closing factory...');
+    try {
+      const res = await FactoriesService.forceCloseFactory(factory.instance_id);
+      setResponseStatus(CallStatus.SUCCESS);
+      setResponseMessage(`Force closed: ${res.n_signed_txs} transactions broadcast`);
+      FactoriesService.fetchFactoriesData();
+      resetStatus();
+    } catch (err: any) {
+      setResponseStatus(CallStatus.ERROR);
+      setResponseMessage(typeof err === 'string' ? err : err.message || 'Force close failed');
+      resetStatus();
+    }
+  };
+
+  const handleOpenChannels = async () => {
+    setResponseStatus(CallStatus.PENDING);
+    setResponseMessage('Opening channels...');
+    try {
+      await FactoriesService.openChannels(factory.instance_id);
+      setResponseStatus(CallStatus.SUCCESS);
+      setResponseMessage('Channel opening initiated');
+      FactoriesService.fetchFactoriesData();
+      resetStatus();
+    } catch (err: any) {
+      setResponseStatus(CallStatus.ERROR);
+      setResponseMessage(typeof err === 'string' ? err : err.message || 'Open channels failed');
+      resetStatus();
+    }
+  };
+
+  const canRotate = factory.lifecycle === FactoryLifecycle.ACTIVE && factory.ceremony === FactoryCeremony.COMPLETE && !factory.rotation_in_progress;
+  const canClose = factory.lifecycle === FactoryLifecycle.ACTIVE;
+  const canForceClose = factory.lifecycle !== FactoryLifecycle.EXPIRED;
+  const canOpenChannels = factory.lifecycle === FactoryLifecycle.ACTIVE && factory.ceremony === FactoryCeremony.COMPLETE;
+
+  return (
+    <Card className='h-100 d-flex align-items-stretch px-4 pt-4 pb-3' data-testid='factory-detail'>
+      <Card.Header className='px-1 pb-2 p-0 d-flex justify-content-between align-items-center'>
+        <span className='fs-18px fw-bold text-dark'>Factory Detail</span>
+        <button className='btn btn-sm btn-outline-secondary btn-rounded' onClick={onClose}>Back</button>
+      </Card.Header>
+      <Card.Body className='py-2 px-1 factory-detail-scroll'>
+        <Row className='mb-2'>
+          <Col xs={12}>
+            <div className='fs-7 text-light'>Instance ID</div>
+            <OverlayTrigger placement='auto' overlay={<Tooltip>Click to copy</Tooltip>}>
+              <div
+                className='fw-bold text-dark fs-7 cursor-pointer text-break'
+                onClick={() => copyTextToClipboard(factory.instance_id)}
+              >
+                {factory.instance_id}
+              </div>
+            </OverlayTrigger>
+          </Col>
+        </Row>
+
+        <Row className='mb-2'>
+          <Col xs={12}>
+            <CeremonyProgress ceremony={factory.ceremony} />
+          </Col>
+        </Row>
+
+        <Row className='mb-2'>
+          <Col xs={6} md={4}>
+            <div className='fs-7 text-light'>Lifecycle</div>
+            <div className='fw-bold text-dark'>{factory.lifecycle}</div>
+          </Col>
+          <Col xs={6} md={4}>
+            <div className='fs-7 text-light'>Role</div>
+            <div className='fw-bold text-dark'>{factory.is_lsp ? 'LSP' : 'Client'}</div>
+          </Col>
+          <Col xs={6} md={4}>
+            <div className='fs-7 text-light'>Clients</div>
+            <div className='fw-bold text-dark'>{factory.n_clients}</div>
+          </Col>
+        </Row>
+
+        <Row className='mb-2'>
+          <Col xs={6} md={4}>
+            <div className='fs-7 text-light'>Epoch</div>
+            <div className='fw-bold text-dark'>{factory.epoch} / {factory.max_epochs}</div>
+          </Col>
+          <Col xs={6} md={4}>
+            <div className='fs-7 text-light'>Channels</div>
+            <div className='fw-bold text-dark'>{factory.n_channels}</div>
+          </Col>
+          <Col xs={6} md={4}>
+            <div className='fs-7 text-light'>Rotation</div>
+            <div className='fw-bold text-dark'>{factory.rotation_in_progress ? 'In Progress' : 'None'}</div>
+          </Col>
+        </Row>
+
+        <Row className='mb-2'>
+          <Col xs={6} md={4}>
+            <div className='fs-7 text-light'>Creation Block</div>
+            <div className='fw-bold text-dark'>{factory.creation_block}</div>
+          </Col>
+          <Col xs={6} md={4}>
+            <div className='fs-7 text-light'>Expiry Block</div>
+            <div className='fw-bold text-dark'>{factory.expiry_block}</div>
+          </Col>
+          <Col xs={6} md={4}>
+            <div className='fs-7 text-light'>Breach Epochs</div>
+            <div className={'fw-bold ' + (factory.n_breach_epochs > 0 ? 'text-danger' : 'text-dark')}>{factory.n_breach_epochs}</div>
+          </Col>
+        </Row>
+
+        <Row className='mb-2'>
+          <Col xs={6} md={4}>
+            <div className='fs-7 text-light'>Dist TX Status</div>
+            <div className='fw-bold text-dark'>{factory.dist_tx_status || 'N/A'}</div>
+          </Col>
+          <Col xs={6} md={8}>
+            <div className='fs-7 text-light'>Funding TXID</div>
+            <OverlayTrigger placement='auto' overlay={<Tooltip>Click to copy</Tooltip>}>
+              <div
+                className='fw-bold text-dark fs-7 cursor-pointer text-break'
+                onClick={() => copyTextToClipboard(factory.funding_txid)}
+              >
+                {factory.funding_txid ? `${factory.funding_txid}:${factory.funding_outnum}` : 'N/A'}
+              </div>
+            </OverlayTrigger>
+          </Col>
+        </Row>
+
+        {factory.channels && factory.channels.length > 0 && (
+          <Row className='mb-2'>
+            <Col xs={12}>
+              <div className='fs-7 text-light fw-bold mb-1'>Factory Channels</div>
+              <ListGroup variant='flush' className='fs-7'>
+                {factory.channels.map((ch, idx) => (
+                  <ListGroup.Item key={ch.channel_id || idx} className='px-0 py-1 d-flex justify-content-between'>
+                    <OverlayTrigger placement='auto' overlay={<Tooltip>Click to copy</Tooltip>}>
+                      <span className='text-dark cursor-pointer' onClick={() => copyTextToClipboard(ch.channel_id)}>
+                        {ch.channel_id.substring(0, 20)}...
+                      </span>
+                    </OverlayTrigger>
+                    <span className='text-light'>leaf {ch.leaf_index} ({ch.leaf_side})</span>
+                  </ListGroup.Item>
+                ))}
+              </ListGroup>
+            </Col>
+          </Row>
+        )}
+
+        {factory.tree_nodes && factory.tree_nodes.length > 0 && (
+          <Row className='mb-2'>
+            <Col xs={12}>
+              <div className='fs-7 text-light fw-bold mb-1'>Tree Nodes ({factory.tree_nodes.length})</div>
+              <ListGroup variant='flush' className='fs-7'>
+                {factory.tree_nodes.map((node, idx) => (
+                  <ListGroup.Item key={idx} className='px-0 py-1 d-flex justify-content-between'>
+                    <span className='text-dark'>#{node.node_idx} {node.type}</span>
+                    {node.txid && (
+                      <OverlayTrigger placement='auto' overlay={<Tooltip>Click to copy TXID</Tooltip>}>
+                        <span className='text-light cursor-pointer' onClick={() => copyTextToClipboard(node.txid!)}>
+                          {node.txid.substring(0, 16)}...
+                        </span>
+                      </OverlayTrigger>
+                    )}
+                  </ListGroup.Item>
+                ))}
+              </ListGroup>
+            </Col>
+          </Row>
+        )}
+
+        {responseStatus !== CallStatus.NONE && (
+          <StatusAlert responseStatus={responseStatus} responseMessage={responseMessage} />
+        )}
+      </Card.Body>
+      <Card.Footer className='d-flex justify-content-center flex-wrap gap-2'>
+        {canOpenChannels && (
+          <button className='btn-rounded bg-success btn-sm' onClick={handleOpenChannels} disabled={responseStatus === CallStatus.PENDING}>
+            Open Channels
+          </button>
+        )}
+        {canRotate && (
+          <button className='btn-rounded bg-primary btn-sm' onClick={handleRotate} disabled={responseStatus === CallStatus.PENDING}>
+            Rotate
+          </button>
+        )}
+        {canClose && (
+          <button className='btn-rounded bg-warning btn-sm' onClick={handleClose} disabled={responseStatus === CallStatus.PENDING}>
+            Close
+          </button>
+        )}
+        {canForceClose && (
+          <button className='btn-rounded bg-danger btn-sm' onClick={handleForceClose} disabled={responseStatus === CallStatus.PENDING}>
+            Force Close
+          </button>
+        )}
+      </Card.Footer>
+    </Card>
+  );
+};
+
+export default FactoryDetail;

--- a/apps/frontend/src/components/factories/FactoryList/FactoryList.scss
+++ b/apps/frontend/src/components/factories/FactoryList/FactoryList.scss
@@ -1,0 +1,8 @@
+@use '../../../styles/constants' as *;
+
+.list-item-factory {
+  cursor: pointer;
+  &:hover {
+    background-color: rgba($primary, 0.08);
+  }
+}

--- a/apps/frontend/src/components/factories/FactoryList/FactoryList.tsx
+++ b/apps/frontend/src/components/factories/FactoryList/FactoryList.tsx
@@ -1,0 +1,104 @@
+import './FactoryList.scss';
+import PerfectScrollbar from 'react-perfect-scrollbar';
+import { Spinner, Card, Row, Col, ListGroup, Alert, OverlayTrigger, Tooltip } from 'react-bootstrap';
+import { ActionSVG } from '../../../svgs/Action';
+import { useSelector } from 'react-redux';
+import { selectIsAuthenticated } from '../../../store/rootSelectors';
+import { selectFactories, selectFactoriesLoading, selectFactoriesError } from '../../../store/factoriesSelectors';
+import { Factory, FactoryLifecycle } from '../../../types/factories.type';
+
+const lifecycleBadge = (lifecycle: FactoryLifecycle) => {
+  switch (lifecycle) {
+    case FactoryLifecycle.ACTIVE: return 'bg-success';
+    case FactoryLifecycle.INIT: return 'bg-warning';
+    case FactoryLifecycle.DYING: return 'bg-warning';
+    case FactoryLifecycle.EXPIRED: return 'bg-danger';
+    default: return 'bg-secondary';
+  }
+};
+
+type FactoryListProps = {
+  onCreateFactory: () => void;
+  onFactoryClick: (factory: Factory) => void;
+};
+
+const FactoryList = (props: FactoryListProps) => {
+  const isAuthenticated = useSelector(selectIsAuthenticated);
+  const factories = useSelector(selectFactories);
+  const isLoading = useSelector(selectFactoriesLoading);
+  const error = useSelector(selectFactoriesError);
+
+  return (
+    <Card className='h-100 d-flex align-items-stretch px-4 pt-4 pb-3' data-testid='factory-list'>
+      <Card.Header className='px-1 pb-2 fs-18px p-0 fw-bold text-dark'>Channel Factories</Card.Header>
+      <Card.Body className='py-0 px-1 channels-scroll-container'>
+        {isAuthenticated && isLoading ?
+          <span className='h-100 d-flex justify-content-center align-items-center'>
+            <Spinner animation='grow' variant='primary' />
+          </span>
+          :
+          error ?
+            <Alert className='fs-8' variant='danger'>{error}</Alert> :
+            factories && factories.length > 0 ?
+              <PerfectScrollbar>
+                <ListGroup as='ul' variant='flush' className='list-channels'>
+                  {factories.map((factory, idx) => (
+                    <li
+                      key={factory.instance_id || idx}
+                      className='list-group-item list-item-channel cursor-pointer'
+                      onClick={() => props.onFactoryClick(factory)}
+                      data-testid='list-item-factory'
+                    >
+                      <div className='list-item-div flex-fill text-dark'>
+                        <div className='d-flex align-items-center justify-content-between'>
+                          <div className='fw-bold'>
+                            <OverlayTrigger
+                              placement='auto'
+                              delay={{ show: 250, hide: 250 }}
+                              overlay={<Tooltip>{factory.lifecycle} - {factory.ceremony}</Tooltip>}
+                            >
+                              <span>
+                                <div className={'d-inline-block mx-1 dot ' + lifecycleBadge(factory.lifecycle)}></div>
+                                {factory.instance_id.substring(0, 16)}...
+                              </span>
+                            </OverlayTrigger>
+                          </div>
+                          <span className='fs-7 text-light'>
+                            {factory.is_lsp ? 'LSP' : 'Client'}
+                          </span>
+                        </div>
+                        <Row className='text-light fs-7 mt-1'>
+                          <Col xs={4}>
+                            Epoch: <span className='fw-bold text-dark'>{factory.epoch}/{factory.max_epochs}</span>
+                          </Col>
+                          <Col xs={4}>
+                            Clients: <span className='fw-bold text-dark'>{factory.n_clients}</span>
+                          </Col>
+                          <Col xs={4}>
+                            Channels: <span className='fw-bold text-dark'>{factory.n_channels}</span>
+                          </Col>
+                        </Row>
+                      </div>
+                    </li>
+                  ))}
+                </ListGroup>
+              </PerfectScrollbar>
+              :
+              <Row className='text-light fs-6 mt-3 h-100 mt-2 align-items-center justify-content-center'>
+                <Row className='d-flex align-items-center justify-content-center'>
+                  <Row className='text-center pb-4'>No factories found. Create a factory to start!</Row>
+                </Row>
+              </Row>
+        }
+      </Card.Body>
+      <Card.Footer className='d-flex justify-content-center'>
+        <button tabIndex={1} className='btn-rounded bg-primary' onClick={props.onCreateFactory} data-testid='button-create-factory'>
+          Create Factory
+          <ActionSVG className='ms-3' />
+        </button>
+      </Card.Footer>
+    </Card>
+  );
+};
+
+export default FactoryList;

--- a/apps/frontend/src/components/factories/FactoryListCard/FactoryListCard.scss
+++ b/apps/frontend/src/components/factories/FactoryListCard/FactoryListCard.scss
@@ -1,0 +1,1 @@
+@use '../../../styles/constants' as *;

--- a/apps/frontend/src/components/factories/FactoryListCard/FactoryListCard.tsx
+++ b/apps/frontend/src/components/factories/FactoryListCard/FactoryListCard.tsx
@@ -1,0 +1,48 @@
+import './FactoryListCard.scss';
+import { useState } from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Card } from 'react-bootstrap';
+import { TRANSITION_DURATION } from '../../../utilities/constants';
+import { Factory } from '../../../types/factories.type';
+import FactoryList from '../FactoryList/FactoryList';
+import FactoryDetail from '../FactoryDetail/FactoryDetail';
+import FactoryCreate from '../FactoryCreate/FactoryCreate';
+
+const FactoryListCard = () => {
+  const [selView, setSelView] = useState<'list' | 'detail' | 'create'>('list');
+  const [selFactory, setSelFactory] = useState<Factory | null>(null);
+
+  return (
+    <Card className='h-100 overflow-hidden inner-box-shadow' data-testid='factory-list-card'>
+      <AnimatePresence mode='wait'>
+        <motion.div
+          key={selView}
+          initial={{ y: 20, opacity: 0 }}
+          animate={{ y: 0, opacity: 1 }}
+          exit={{ y: -20, opacity: 0 }}
+          transition={{ duration: TRANSITION_DURATION }}
+          className='h-100 overflow-hidden'
+        >
+          {selView === 'create' ? (
+            <FactoryCreate onClose={() => setSelView('list')} />
+          ) : selView === 'detail' && selFactory ? (
+            <FactoryDetail
+              factory={selFactory}
+              onClose={() => setSelView('list')}
+            />
+          ) : (
+            <FactoryList
+              onCreateFactory={() => setSelView('create')}
+              onFactoryClick={(factory) => {
+                setSelFactory(factory);
+                setSelView('detail');
+              }}
+            />
+          )}
+        </motion.div>
+      </AnimatePresence>
+    </Card>
+  );
+};
+
+export default FactoryListCard;

--- a/apps/frontend/src/components/factories/LadderingTimeline/LadderingTimeline.scss
+++ b/apps/frontend/src/components/factories/LadderingTimeline/LadderingTimeline.scss
@@ -1,0 +1,46 @@
+@use '../../../styles/constants' as *;
+
+.timeline-container {
+  position: relative;
+  padding-bottom: 8px;
+}
+
+.timeline-row {
+  position: relative;
+}
+
+.timeline-bar-container {
+  position: relative;
+  height: 12px;
+  background-color: $gray-200;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.timeline-bar {
+  position: absolute;
+  height: 100%;
+  border-radius: 6px;
+  opacity: 0.85;
+  transition: width 0.3s ease;
+}
+
+.timeline-current-marker {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background-color: $primary;
+  z-index: 1;
+
+  &::after {
+    content: 'Now';
+    position: absolute;
+    bottom: -16px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 0.65rem;
+    color: $primary;
+    white-space: nowrap;
+  }
+}

--- a/apps/frontend/src/components/factories/LadderingTimeline/LadderingTimeline.tsx
+++ b/apps/frontend/src/components/factories/LadderingTimeline/LadderingTimeline.tsx
@@ -1,0 +1,78 @@
+import './LadderingTimeline.scss';
+import { Card } from 'react-bootstrap';
+import { useSelector } from 'react-redux';
+import { selectNodeInfo } from '../../../store/rootSelectors';
+import { selectFactories, selectFactoriesLoading } from '../../../store/factoriesSelectors';
+import { FactoryLifecycle } from '../../../types/factories.type';
+
+const LadderingTimeline = () => {
+  const nodeInfo = useSelector(selectNodeInfo);
+  const factories = useSelector(selectFactories);
+  const isLoading = useSelector(selectFactoriesLoading);
+
+  const currentBlock = nodeInfo.blockheight || 0;
+  const timelineFactories = factories
+    .filter(f => f.creation_block > 0 && f.expiry_block > 0)
+    .sort((a, b) => a.creation_block - b.creation_block);
+
+  if (isLoading || timelineFactories.length === 0) {
+    return null;
+  }
+
+  const minBlock = Math.min(...timelineFactories.map(f => f.creation_block));
+  const maxBlock = Math.max(...timelineFactories.map(f => f.expiry_block));
+  const range = maxBlock - minBlock || 1;
+
+  const getColor = (lifecycle: FactoryLifecycle) => {
+    switch (lifecycle) {
+      case FactoryLifecycle.ACTIVE: return '#33db95';
+      case FactoryLifecycle.INIT: return '#e1ba2d';
+      case FactoryLifecycle.DYING: return '#fe8e02';
+      case FactoryLifecycle.EXPIRED: return '#dc3545';
+      default: return '#6c757d';
+    }
+  };
+
+  const currentPosition = ((currentBlock - minBlock) / range) * 100;
+
+  return (
+    <Card className='inner-box-shadow mb-4' data-testid='laddering-timeline'>
+      <Card.Body className='px-4 pt-3 pb-3'>
+        <div className='fs-18px fw-bold text-dark mb-3'>Factory Timeline</div>
+        <div className='timeline-container'>
+          {timelineFactories.map(factory => {
+            const left = ((factory.creation_block - minBlock) / range) * 100;
+            const width = ((factory.expiry_block - factory.creation_block) / range) * 100;
+            return (
+              <div key={factory.instance_id} className='timeline-row mb-2'>
+                <div className='fs-8 text-light mb-1'>
+                  {factory.instance_id.substring(0, 10)}...
+                </div>
+                <div className='timeline-bar-container'>
+                  <div
+                    className='timeline-bar'
+                    style={{
+                      left: `${left}%`,
+                      width: `${Math.max(width, 1)}%`,
+                      backgroundColor: getColor(factory.lifecycle),
+                    }}
+                    title={`Blocks ${factory.creation_block} - ${factory.expiry_block} (${factory.lifecycle})`}
+                  />
+                </div>
+              </div>
+            );
+          })}
+          {currentPosition >= 0 && currentPosition <= 100 && (
+            <div
+              className='timeline-current-marker'
+              style={{ left: `${currentPosition}%` }}
+              title={`Current: block ${currentBlock}`}
+            />
+          )}
+        </div>
+      </Card.Body>
+    </Card>
+  );
+};
+
+export default LadderingTimeline;

--- a/apps/frontend/src/components/ui/Menu/Menu.tsx
+++ b/apps/frontend/src/components/ui/Menu/Menu.tsx
@@ -5,25 +5,32 @@ import { useSelector } from 'react-redux';
 import { selectIsAuthenticated, selectNodeInfo } from '../../../store/rootSelectors';
 import { HomeSVG } from '../../../svgs/Home';
 import { BookkeeperSVG } from '../../../svgs/Bookkeeper';
+import { FactorySVG } from '../../../svgs/Factory';
+
+const menuItems = [
+  { path: '/cln', label: 'Dashboard', icon: HomeSVG },
+  { path: '/bookkeeper', label: 'Bookkeeper', icon: BookkeeperSVG },
+  { path: '/factories', label: 'Factories', icon: FactorySVG },
+];
 
 const Menu = props => {
   const isAuthenticated = useSelector(selectIsAuthenticated);
   const nodeInfo = useSelector(selectNodeInfo);
   const location = useLocation();
 
+  const isDisabled = !!(nodeInfo.error || (isAuthenticated && nodeInfo.isLoading));
+  const currentItem = menuItems.find(item => location.pathname.includes(item.path)) || menuItems[0];
+  const otherItems = menuItems.filter(item => item.path !== currentItem.path);
+  const CurrentIcon = currentItem.icon;
+
   return (
     <Dropdown
-      as={Link} to={location.pathname.includes('/bookkeeper') ? '/cln' : '/bookkeeper'}
-      className={
-        !!(nodeInfo.error || (isAuthenticated && nodeInfo.isLoading))
-          ? 'me-2 menu-dropdown dropdown-disabled'
-          : 'me-2 menu-dropdown'
-      }
+      className={isDisabled ? 'me-2 menu-dropdown dropdown-disabled' : 'me-2 menu-dropdown'}
       data-testid="menu"
     >
       <Dropdown.Toggle
         variant={props.compact ? '' : 'primary'}
-        disabled={!!(nodeInfo.error || (isAuthenticated && nodeInfo.isLoading))}
+        disabled={isDisabled}
         className={
           props.compact
             ? 'd-flex align-items-center justify-content-between btn-rounded btn-compact btn-menu'
@@ -31,10 +38,21 @@ const Menu = props => {
         }
       >
         <span className={props.compact ? '' : 'me-3'}>
-          <span className={props.compact ? '' : 'me-2'}>{props.compact ? '' : location.pathname.includes('bookkeeper') ? 'Dashboard' : 'Bookkeeper'}</span>
-          {location.pathname.includes('bookkeeper') ? <HomeSVG className={((!!nodeInfo.error || (isAuthenticated && nodeInfo.isLoading)) ? 'svg-fill-disabled' : '')} /> : <BookkeeperSVG className={((!!nodeInfo.error || (isAuthenticated && nodeInfo.isLoading)) ? 'svg-fill-disabled' : '')} />}
+          <span className={props.compact ? '' : 'me-2'}>{props.compact ? '' : currentItem.label}</span>
+          <CurrentIcon className={isDisabled ? 'svg-fill-disabled' : ''} />
         </span>
       </Dropdown.Toggle>
+      <Dropdown.Menu>
+        {otherItems.map(item => {
+          const Icon = item.icon;
+          return (
+            <Dropdown.Item key={item.path} as={Link} to={item.path}>
+              <Icon className='me-2' />
+              {item.label}
+            </Dropdown.Item>
+          );
+        })}
+      </Dropdown.Menu>
     </Dropdown>
   );
 };

--- a/apps/frontend/src/routes/dataLoader.tsx
+++ b/apps/frontend/src/routes/dataLoader.tsx
@@ -1,5 +1,5 @@
 import { LoaderFunctionArgs } from "react-router-dom";
-import { BookkeeperService, CLNService, RootService } from "../services/http.service";
+import { BookkeeperService, CLNService, FactoriesService, RootService } from "../services/http.service";
 import { appStore } from "../store/appStore";
 import { AppState } from "../store/store.type";
 
@@ -27,6 +27,15 @@ export async function bkprLoader({}: LoaderFunctionArgs) {
   if (state.root.authStatus.isAuthenticated) {
     const bkprData = await BookkeeperService.fetchBKPRData();
     return bkprData;
+  }
+  return null;
+}
+
+export async function factoriesLoader({}: LoaderFunctionArgs) {
+  const state = appStore.getState() as AppState;
+  if (state.root.authStatus.isAuthenticated) {
+    const factoriesData = await FactoriesService.fetchFactoriesData();
+    return factoriesData;
   }
   return null;
 }

--- a/apps/frontend/src/routes/router.config.tsx
+++ b/apps/frontend/src/routes/router.config.tsx
@@ -10,6 +10,7 @@ import { RootRouterReduxSync } from './routerReduxSync';
 const App = lazy(() => import('../components/App/App'));
 const CLNHome = lazy(() => import('../components/cln/CLNHome/CLNHome'));
 const Bookkeeper = lazy(() => import('../components/bookkeeper/BkprHome/BkprHome'));
+const FactoriesHome = lazy(() => import('../components/factories/FactoriesHome/FactoriesHome'));
 
 export const rootRouteConfig = [
   {
@@ -28,6 +29,14 @@ export const rootRouteConfig = [
         element: (
           <Suspense fallback={<Loading />}>
             <CLNHome />
+          </Suspense>
+        ),
+      },
+      {
+        path: 'factories',
+        element: (
+          <Suspense fallback={<Loading />}>
+            <FactoriesHome />
           </Suspense>
         ),
       },

--- a/apps/frontend/src/routes/routerReduxSync.tsx
+++ b/apps/frontend/src/routes/routerReduxSync.tsx
@@ -2,9 +2,10 @@ import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { clearBKPRStore } from '../store/bkprSlice';
 import { clearCLNStore } from '../store/clnSlice';
+import { clearFactoriesStore } from '../store/factoriesSlice';
 import { APP_WAIT_TIME } from '../utilities/constants';
 import { useDispatch, useSelector } from 'react-redux';
-import { BookkeeperService, CLNService, RootService } from '../services/http.service';
+import { BookkeeperService, CLNService, FactoriesService, RootService } from '../services/http.service';
 import { selectAuthStatus } from '../store/rootSelectors';
 import logger from '../services/logger.service';
 
@@ -22,6 +23,9 @@ export function RootRouterReduxSync() {
       if (document.visibilityState === 'visible' && authStatus?.isAuthenticated) {
         try {
           await RootService.refreshData();
+          if (pathname.includes('/factories')) {
+            await FactoriesService.fetchFactoriesData();
+          }
         } catch (error) {
           logger.error('Error fetching root data:', error);
         }
@@ -48,8 +52,17 @@ export function RootRouterReduxSync() {
           logger.error('Error fetching BKPR data:', error);
         }
       }
+      else if (pathname.includes('/factories')) {
+        try {
+          await FactoriesService.fetchFactoriesData();
+        } catch (error) {
+          logger.error('Error fetching factories data:', error);
+        }
+      }
     };
-    const targetPath = pathname.includes('/bookkeeper') ? pathname : '/cln';
+    const targetPath = pathname.includes('/bookkeeper') ? pathname
+      : pathname.includes('/factories') ? pathname
+      : '/cln';
     fetchRouteData();
     if (pathname !== targetPath) {
       navigate(targetPath, { replace: true });
@@ -64,6 +77,9 @@ export function RootRouterReduxSync() {
       }
       else if (pathname.includes('/bookkeeper')) {
         dispatch(clearBKPRStore());
+      }
+      else if (pathname.includes('/factories')) {
+        dispatch(clearFactoriesStore());
       }
     };
   }, [pathname, dispatch]);

--- a/apps/frontend/src/services/http.service.ts
+++ b/apps/frontend/src/services/http.service.ts
@@ -13,6 +13,8 @@ import { listBTCTransactionsSQL, listLightningTransactionsSQL, ListOffersSQL, Li
 import { setConnectWallet, setListChannels, setListFunds, setNodeInfo } from '../store/rootSlice';
 import { setFeeRate, setListBitcoinTransactions, setListLightningTransactions, setListOffers } from '../store/clnSlice';
 import { setAccountEvents, setSatsFlow, setVolume } from '../store/bkprSlice';
+import { setFactoryList } from '../store/factoriesSlice';
+import { Factory, FactoryCreateResponse, FactoryRotateResponse, FactoryCloseResponse, FactoryForceCloseResponse, FactoryCheckBreachResponse } from '../types/factories.type';
 import { isCompatibleVersion } from '../utilities/data-formatters';
 
 const axiosInstance = axios.create({
@@ -538,5 +540,56 @@ export class BookkeeperService {
       };
     }
   }
-  
+
+}
+
+export class FactoriesService {
+  static async listFactories(): Promise<{ factories: Factory[] }> {
+    return HttpService.clnCall('factory-list');
+  }
+
+  static async createFactory(fundingSats: number, clients: string[]): Promise<FactoryCreateResponse> {
+    return HttpService.clnCall('factory-create', { funding_sats: fundingSats, clients });
+  }
+
+  static async rotateFactory(instanceId: string): Promise<FactoryRotateResponse> {
+    return HttpService.clnCall('factory-rotate', { instance_id: instanceId });
+  }
+
+  static async closeFactory(instanceId: string): Promise<FactoryCloseResponse> {
+    return HttpService.clnCall('factory-close', { instance_id: instanceId });
+  }
+
+  static async forceCloseFactory(instanceId: string): Promise<FactoryForceCloseResponse> {
+    return HttpService.clnCall('factory-force-close', { instance_id: instanceId });
+  }
+
+  static async checkBreach(instanceId: string, txid: string, vout: number, amountSats: number, epoch: number): Promise<FactoryCheckBreachResponse> {
+    return HttpService.clnCall('factory-check-breach', {
+      instance_id: instanceId, txid, vout, amount_sats: amountSats, epoch,
+    });
+  }
+
+  static async openChannels(instanceId: string): Promise<any> {
+    return HttpService.clnCall('factory-open-channels', { instance_id: instanceId });
+  }
+
+  static async fetchFactoriesData() {
+    const state = appStore.getState() as AppState;
+    if (state.root.authStatus.isAuthenticated) {
+      const results = await executeRequests(
+        {
+          factoryList: this.listFactories(),
+        },
+        (key, data) => {
+          switch (key) {
+            case 'factoryList':
+              appStore.dispatch(setFactoryList(data));
+              break;
+          }
+        }
+      );
+      return { factoryList: results.factoryList };
+    }
+  }
 }

--- a/apps/frontend/src/store/factoriesSelectors.tsx
+++ b/apps/frontend/src/store/factoriesSelectors.tsx
@@ -1,0 +1,52 @@
+import { createSelector } from '@reduxjs/toolkit';
+import { FactoriesState, FactoryLifecycle } from '../types/factories.type';
+
+export const defaultFactoriesState: FactoriesState = {
+  factoryList: { isLoading: true, factories: [] },
+  selectedFactory: null,
+  actionStatus: { action: null, status: 'idle', message: '' },
+};
+
+const selectFactoriesState = (state: { factories: FactoriesState }) =>
+  state.factories || defaultFactoriesState;
+
+export const selectFactoryList = createSelector(
+  selectFactoriesState,
+  (f) => f.factoryList
+);
+
+export const selectFactories = createSelector(
+  selectFactoryList,
+  (fl) => fl.factories
+);
+
+export const selectFactoriesLoading = createSelector(
+  selectFactoryList,
+  (fl) => fl.isLoading
+);
+
+export const selectFactoriesError = createSelector(
+  selectFactoryList,
+  (fl) => fl.error
+);
+
+export const selectSelectedFactory = createSelector(
+  selectFactoriesState,
+  (f) => f.selectedFactory
+);
+
+export const selectActionStatus = createSelector(
+  selectFactoriesState,
+  (f) => f.actionStatus
+);
+
+export const selectFactoryCounts = createSelector(
+  selectFactories,
+  (factories) => ({
+    total: factories.length,
+    active: factories.filter(f => f.lifecycle === FactoryLifecycle.ACTIVE).length,
+    init: factories.filter(f => f.lifecycle === FactoryLifecycle.INIT).length,
+    dying: factories.filter(f => f.lifecycle === FactoryLifecycle.DYING).length,
+    expired: factories.filter(f => f.lifecycle === FactoryLifecycle.EXPIRED).length,
+  })
+);

--- a/apps/frontend/src/store/factoriesSlice.tsx
+++ b/apps/frontend/src/store/factoriesSlice.tsx
@@ -1,0 +1,47 @@
+import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { Factory, FactoriesState } from '../types/factories.type';
+import { defaultFactoriesState } from './factoriesSelectors';
+
+const factoriesSlice = createSlice({
+  name: 'factories',
+  initialState: defaultFactoriesState,
+  reducers: {
+    setFactoryList(state, action: PayloadAction<{ factories?: Factory[]; error?: any; isLoading?: boolean }>) {
+      if (action.payload.error) {
+        state.factoryList = { ...state.factoryList, error: action.payload.error, isLoading: false };
+        return;
+      }
+      state.factoryList = {
+        isLoading: false,
+        factories: action.payload.factories || [],
+        error: undefined,
+      };
+    },
+    setFactoryListLoading(state, action: PayloadAction<boolean>) {
+      state.factoryList.isLoading = action.payload;
+    },
+    setSelectedFactory(state, action: PayloadAction<Factory | null>) {
+      state.selectedFactory = action.payload;
+    },
+    setActionStatus(state, action: PayloadAction<FactoriesState['actionStatus']>) {
+      state.actionStatus = action.payload;
+    },
+    clearActionStatus(state) {
+      state.actionStatus = defaultFactoriesState.actionStatus;
+    },
+    clearFactoriesStore() {
+      return defaultFactoriesState;
+    },
+  },
+});
+
+export const {
+  setFactoryList,
+  setFactoryListLoading,
+  setSelectedFactory,
+  setActionStatus,
+  clearActionStatus,
+  clearFactoriesStore,
+} = factoriesSlice.actions;
+
+export default factoriesSlice.reducer;

--- a/apps/frontend/src/store/store.type.ts
+++ b/apps/frontend/src/store/store.type.ts
@@ -1,6 +1,7 @@
 import { EnhancedStore } from "@reduxjs/toolkit";
 import { BKPRState } from "../types/bookkeeper.type";
 import { CLNState } from "../types/cln.type";
+import { FactoriesState } from "../types/factories.type";
 import { RootState } from "../types/root.type";
 
 export type ReducerManager = {
@@ -20,4 +21,5 @@ export type AppState = {
   root: RootState;
   cln?: CLNState;
   bkpr?: BKPRState;
+  factories?: FactoriesState;
 };

--- a/apps/frontend/src/svgs/Factory.tsx
+++ b/apps/frontend/src/svgs/Factory.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+export const FactorySVG = props => {
+  return (
+    <svg
+      className={props.className}
+      width='20'
+      height='20'
+      viewBox='0 0 24 24'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <path
+        d='M2 20V9l4-5v4l4-4v4l4-4v10h8V8h-6V4h8v16H2Zm2-2h16V12H14v-1.6l-4 4V12.8l-4 4V12.8L4 15.6V18Zm2-2h2v-2H8v2Zm4 0h2v-2h-2v2Zm4 0h2v-2h-2v2Z'
+        className='fill-contrast'
+      />
+    </svg>
+  );
+};

--- a/apps/frontend/src/types/factories.type.ts
+++ b/apps/frontend/src/types/factories.type.ts
@@ -1,0 +1,106 @@
+export enum FactoryLifecycle {
+  INIT = 'INIT',
+  ACTIVE = 'ACTIVE',
+  DYING = 'DYING',
+  EXPIRED = 'EXPIRED',
+}
+
+export enum FactoryCeremony {
+  IDLE = 'IDLE',
+  PROPOSED = 'PROPOSED',
+  NONCES_COLLECTED = 'NONCES_COLLECTED',
+  PSIGS_COLLECTED = 'PSIGS_COLLECTED',
+  COMPLETE = 'COMPLETE',
+  ROTATING = 'ROTATING',
+  ROTATE_COMPLETE = 'ROTATE_COMPLETE',
+  REVOKED = 'REVOKED',
+  FAILED = 'FAILED',
+}
+
+export type FactoryChannel = {
+  channel_id: string;
+  leaf_index: number;
+  leaf_side: string;
+};
+
+export type TreeNode = {
+  node_idx: number;
+  type: string;
+  txid?: string;
+  [key: string]: any;
+};
+
+export type Factory = {
+  instance_id: string;
+  is_lsp: boolean;
+  n_clients: number;
+  epoch: number;
+  n_channels: number;
+  lifecycle: FactoryLifecycle;
+  ceremony: FactoryCeremony;
+  max_epochs: number;
+  creation_block: number;
+  expiry_block: number;
+  rotation_in_progress: boolean;
+  n_breach_epochs: number;
+  dist_tx_status: string;
+  tree_nodes: TreeNode[];
+  funding_txid: string;
+  funding_outnum: number;
+  channels: FactoryChannel[];
+};
+
+export type FactoryCreateResponse = {
+  instance_id: string;
+  n_clients: number;
+  ceremony: FactoryCeremony;
+};
+
+export type FactoryRotateResponse = {
+  instance_id: string;
+  old_epoch: number;
+  new_epoch: number;
+  ceremony: FactoryCeremony;
+};
+
+export type FactoryCloseResponse = {
+  instance_id: string;
+  status: string;
+};
+
+export type FactoryForceCloseTransaction = {
+  node_idx: number;
+  type: string;
+  txid: string;
+  raw_tx: string;
+  tx_len: number;
+};
+
+export type FactoryForceCloseResponse = {
+  instance_id: string;
+  n_signed_txs: number;
+  status: string;
+  transactions: FactoryForceCloseTransaction[];
+};
+
+export type FactoryCheckBreachResponse = {
+  burn_tx: string;
+  burn_tx_len: number;
+  epoch: number;
+  status: string;
+};
+
+export type FactoriesState = {
+  factoryList: {
+    isLoading: boolean;
+    factories: Factory[];
+    error?: any;
+  };
+  selectedFactory: Factory | null;
+  actionStatus: {
+    action: string | null;
+    status: 'idle' | 'pending' | 'success' | 'error';
+    message: string;
+    data?: any;
+  };
+};


### PR DESCRIPTION
## Summary

- Adds a complete **Factories tab** for managing SuperScalar channel factories alongside the existing Dashboard and Bookkeeper tabs
- Rewrites the 2-way menu toggle into a proper 3-way dropdown navigation
- All 7 SuperScalar CLN plugin RPCs wired up (`factory-list`, `factory-create`, `factory-rotate`, `factory-close`, `factory-force-close`, `factory-check-breach`, `factory-open-channels`)
- Zero backend changes — uses the existing generic `POST /v1/cln/call` proxy

## What's Included

| Component | Description |
|-----------|-------------|
| **FactoriesOverview** | Summary counters (total, active, init, dying, expired) with animated countups |
| **FactoryList** | Scrollable list with lifecycle/ceremony badges, click to expand |
| **FactoryDetail** | Full metadata view: instance ID, epoch, channels, tree nodes, funding TXID |
| **FactoryCreate** | Creation form: funding amount + client node IDs |
| **Action Buttons** | Rotate, Close, Force Close, Open Channels (conditional on lifecycle/ceremony state) |
| **ExpiryWarnings** | Progress bars showing blocks remaining per factory |
| **BreachStatus** | Flags factories with breach epochs detected |
| **CeremonyProgress** | Step indicator for MuSig2 ceremony stages |
| **LadderingTimeline** | Visual timeline of factory creation-to-expiry ranges |
| **3-way Menu** | Dropdown nav replacing the old 2-way toggle |

## Architecture

Follows all existing codebase patterns:
- Dynamic reducer injection via `useInjectReducer('factories', reducer)`
- Redux Toolkit slice + memoized selectors
- `FactoriesService` class in `http.service.ts`
- React Router lazy loading for `/factories` route
- `routerReduxSync` integration for data fetching, cleanup, and polling

## Files Changed

- **6 modified**: store.type.ts, http.service.ts, router.config.tsx, dataLoader.tsx, routerReduxSync.tsx, Menu.tsx
- **25 new**: types, slice, selectors, SVG icon, 10 components (each with .tsx + .scss)

## Test Plan

- [ ] `npm run build` succeeds with no TypeScript errors
- [ ] Navigate to `/factories` via the new 3-way menu dropdown
- [ ] Menu shows correct context from all 3 routes (Dashboard, Bookkeeper, Factories)
- [ ] Factory list renders data from `factory-list` RPC (or shows error gracefully without plugin)
- [ ] Click factory -> detail view -> back transitions work
- [ ] Create/Rotate/Close/ForceClose call correct RPCs
- [ ] Expiry warnings and breach status display correctly
- [ ] All existing Dashboard and Bookkeeper functionality unchanged